### PR TITLE
Add scroll-based header/footer visibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,56 @@
 import { styled } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
 import "./App.css";
-import Footer from "./components/Footer";
-import { Header } from "./components/Header";
+import Footer, { FOOTER_HEIGHT } from "./components/Footer";
+import { Header, HEADER_HEIGHT } from "./components/Header";
 import { Router } from "./components/Router";
 
 const Container = styled("div")`
+  height: 100vh;
+  overflow-y: auto;
+  margin: 0;
+  padding-top: ${HEADER_HEIGHT}px;
+  padding-bottom: ${FOOTER_HEIGHT}px;
+  background-color: #f9f9f9;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  margin: 0;
-  padding: 0;
-  background-color: #f9f9f9;
 `;
 
 function App() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [showHeader, setShowHeader] = useState(true);
+  const [showFooter, setShowFooter] = useState(true);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      const atTop = el.scrollTop <= 0;
+      const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight;
+      const noScroll = el.scrollHeight <= el.clientHeight;
+
+      if (noScroll) {
+        setShowHeader(true);
+        setShowFooter(true);
+      } else {
+        setShowHeader(atTop);
+        setShowFooter(atBottom);
+      }
+    };
+
+    el.addEventListener("scroll", handleScroll);
+    handleScroll();
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, []);
+
   return (
-    <Container>
-      <Header />
-      <div style={{ flex: 1, width: '100%' }}>
+    <Container ref={containerRef}>
+      <Header visible={showHeader} />
+      <div style={{ flex: 1, width: "100%" }}>
         <Router />
       </div>
-      <Footer />
+      <Footer visible={showFooter} />
     </Container>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,19 +1,27 @@
 import { Box, styled } from "@mui/material";
 
-const FooterContainer = styled(Box)`
+export const FOOTER_HEIGHT = 70;
+
+const FooterContainer = styled(Box)<{visible: boolean}>`
   width: 100%;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  height: 70px;
+  height: ${FOOTER_HEIGHT}px;
   background-color: #0f172a;
   color: #f0f2f5;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  transform: translateY(${({ visible }) => (visible ? "0" : "100%")});
+  transition: transform 0.3s;
+  z-index: 1000;
 `;
 
-export const Footer = () => {
+export const Footer = ({ visible = true }: { visible?: boolean }) => {
   return (
-    <FooterContainer>
+    <FooterContainer visible={visible}>
       <h1>FOOTER</h1>
     </FooterContainer>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,22 @@
 import { Box, Button, styled } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
-const HeaderContainer = styled(Box)`
+export const HEADER_HEIGHT = 70;
+
+const HeaderContainer = styled(Box)<{visible: boolean}>`
   width: 100%;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  height: 70px;
+  height: ${HEADER_HEIGHT}px;
   background-color: #0f172a;
+  position: fixed;
+  top: 0;
+  left: 0;
+  transform: translateY(${({ visible }) => (visible ? "0" : "-100%")});
+  transition: transform 0.3s;
+  z-index: 1000;
 `;
 
 const StyledTitle = styled("h1")`
@@ -38,12 +46,12 @@ const StyledButton = styled(Button)`
   }
 `;
 
-export const Header = () => {
+export const Header = ({ visible = true }: { visible?: boolean }) => {
 
   const navigate = useNavigate();
 
   return (
-    <HeaderContainer>
+    <HeaderContainer visible={visible}>
       <StyledTitle>Navpreet Once</StyledTitle>
       <ButtonsGroup>
         <StyledButton onClick={() => navigate("/")}>Home</StyledButton>


### PR DESCRIPTION
## Summary
- make header and footer fixed and hide using a transform
- scroll container now has padding for the header and footer
- show header when scrolled to top and footer when scrolled to bottom

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module '@mui/material')*

------
https://chatgpt.com/codex/tasks/task_e_68547a9bd2848329accfc879865fc606